### PR TITLE
fixed exit fct and ctrl+D signal

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -35,7 +35,7 @@ typedef enum s_tokentype
 typedef struct s_env
 {
 	char	**env_cpy;
-	int		exit_requested;
+	int		exit_status;
 }	t_env;
 
 typedef struct s_node
@@ -123,8 +123,14 @@ void	run_exec(t_node *tree, t_env *env);
 void	ft_cd(char **args, t_env *env);
 void	ft_pwd(void);
 void	ft_echo(char **args);
-int		ft_exit(void);
 void	ft_env(t_env *env);
+
+/* EXIT */
+void	actualize_status_and_exit(char *status, t_env *env);
+void	ft_exit(char **args, t_env *env);
+void	is_input_exit(char *input);
+void	ft_exit_and_free(char **input_cpy);
+
 
 /* EXPORT */
 int		is_var_valid(char *var);

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -1,8 +1,87 @@
 #include "../../include/minishell.h"
 
 //fonctions de free a ajouter
-int	ft_exit()
+void	is_input_exit(char *input)
 {
-	printf("exit\n");
-	exit (1);
+	int	i;
+	char **input_cpy;
+
+	i = 0;
+	input_cpy = ft_split(input, ' ');
+	if (strcmp(input_cpy[0], "exit") == 0)
+	{
+		while (input_cpy[i])
+			i++;
+		if (i > 2)
+		{
+			printf("exit\nminishell: exit: too many arguments\n");
+			free_tab(input_cpy);
+			return ;
+		}
+		else
+		{
+			printf("exit\n");
+			ft_exit_and_free(input_cpy);
+		}
+	}
+	return ;
+}
+
+void	ft_exit_and_free(char **input_cpy)
+{
+	int	i;
+
+	if (input_cpy[1])
+	{
+		i = 0;
+		while (input_cpy[1][i])
+		{
+			if (!ft_isdigit(input_cpy[1][i]))
+			{
+				printf("exit\nminishell: exit: %s: numeric argument required\n", input_cpy[1]);
+				free_tab(input_cpy);
+				exit (1);
+			}
+			i++;
+		}
+	}
+	free_tab(input_cpy);
+	exit(1);
+}
+
+void	actualize_status_and_exit(char *status, t_env *env)
+{
+	env->exit_status = ft_atoi(status);
+	if (env->exit_status >= 0 && env->exit_status <= 255)
+		exit(env->exit_status);
+	else
+	{
+		env->exit_status %= 256;
+		exit(env->exit_status);
+	}
+}
+
+void	ft_exit(char **args, t_env *env)
+{
+	int	i;
+
+	if (args[1])
+	{
+		i = 0;
+		while (args[1][i])
+		{
+			if (!ft_isdigit(args[1][i]))
+			{
+				printf("exit\nminishell: exit: %s: numeric argument required\n", args[1]);
+				exit (1);
+			}
+			i++;
+		}
+		actualize_status_and_exit(args[1], env);
+	}
+	else
+	{
+		env->exit_status = 1;
+		exit(1);
+	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -47,18 +47,25 @@ int	main(int ac, char **av, char **env)
 	if (!new_env)
 		return (1);
 	new_env->env_cpy  = dup_env(env);
-	new_env->exit_requested = 0;
+	new_env->exit_status = 0;
 	handle_sigint();
 	handle_sigquit();
-	while (new_env->exit_requested != 1)
+	while (1)
 	{
-		input = readline("minishell > ");
+		input = readline("minishell $ ");
 		if (input == NULL)
+		{
+			printf("exit\n");
 			return (1);
+		}
+		is_input_exit(input);
 		add_history(input);
 		tree = parse_input(input);
 		if (ft_fork() == 0)
 			run(tree, new_env);
 		wait(NULL);
+		free(input);
 	}
+	free(new_env);
+	return (0);
 }

--- a/src/parse/create_nodes.c
+++ b/src/parse/create_nodes.c
@@ -16,7 +16,7 @@ t_node	*create_redir_node(t_node *cmd, char *start_file, char *end_file, int mod
 	redir_node->cmd = cmd;
 	redir_node->file = start_file;
 	redir_node->end_file = end_file;
-	printf("end file = %s\n", end_file);
+	//printf("end file = %s\n", end_file);
 	redir_node->mode = mode;
 	redir_node->fd = fd;
 	return ((t_node *)redir_node);

--- a/src/parse/parsing.c
+++ b/src/parse/parsing.c
@@ -41,9 +41,9 @@ t_node	*parse_exec(char **start_scan, char *end_input)
 		if ((type = get_token(start_scan, end_input, &start_token, &end_token)) == -1)
 			break;
 		exec_node->args[i] = start_token;
-		printf("start token = %s\n", exec_node->args[i]);
+		//printf("start token = %s\n", exec_node->args[i]);
 		exec_node->end_args[i] = end_token;
-		printf("end token = %s\n", exec_node->end_args[i]);
+		//printf("end token = %s\n", exec_node->end_args[i]);
 		i++;
 		if (i >= MAX_ARGS)
 			printf("error, too many arguments.\n");

--- a/src/run/run.c
+++ b/src/run/run.c
@@ -18,4 +18,5 @@ void	run(t_node *tree, t_env *env)
 		run_redir(tree, env);
 	else if (tree->type == PIPE)
 		run_pipe(tree, env);
+	exit (0);
 }

--- a/src/run/run_builtin.c
+++ b/src/run/run_builtin.c
@@ -11,10 +11,7 @@ void	run_builtin(char **args, t_env *env)
 	else if (ft_strncmp(args[0], "export", 6) == 0)
 		ft_export(args, env);
 	else if (ft_strncmp(args[0], "exit", 4) == 0)
-	{
-		env->exit_requested = 1;
-		ft_exit();
-	}
+		ft_exit(args, env);
 	else if (ft_strncmp(args[0], "env", 3) == 0)
 		ft_env(env);
 	return ;


### PR DESCRIPTION
implemented exit fct in every case it is usable. the function record the exit status in env struct so we can call it when there is a $? in the input.

also fixed the signal ctrl+D that was not working well. It now exits properly and print "exit" while doing so. 